### PR TITLE
Added support for ignored functions.

### DIFF
--- a/PHPUnit/Util/Log/XHProf.php
+++ b/PHPUnit/Util/Log/XHProf.php
@@ -69,6 +69,9 @@
  *     <element key="xhprofFlags">
  *      <string>XHPROF_FLAGS_CPU,XHPROF_FLAGS_MEMORY</string>
  *     </element>
+ *     <element key="xhprofIgnore">
+ *      <string>call_user_func,call_user_func_array</string>
+ *     </element>
  *    </array>
  *   </arguments>
  *  </listener>
@@ -196,7 +199,9 @@ class PHPUnit_Util_Log_XHProf implements PHPUnit_Framework_TestListener
             }
         }
 
-        xhprof_enable($flags);
+        xhprof_enable($flags, array(
+            'ignored_functions' => explode(',', $this->options['xhprofIgnore'])
+        ));
     }
 
     /**


### PR DESCRIPTION
The 'xhprof_enable' function supports ignored functions as a optional second parameter. This is configurable via the phpunit.xml as element key 'xhprofIgnore' similar to 'xhprofFlags'. See the code example in the source file for details.
