### PR TITLE
Set source name with appNamespace and testcase name

### DIFF
--- a/PHPUnit/Util/Log/XHProf.php
+++ b/PHPUnit/Util/Log/XHProf.php
@@ -214,9 +214,9 @@ class PHPUnit_Util_Log_XHProf implements PHPUnit_Framework_TestListener
     {
         $data         = xhprof_disable();
         $runs         = new XHProfRuns_Default;
-        $run          = $runs->save_run($data, $this->options['appNamespace']);
-        $this->runs[$test->getName()] = $this->options['xhprofWeb'] . '?run=' . $run .
-                                        '&source=' . $this->options['appNamespace'];
+        $source       = $this->options['appNamespace'] . '_' . $test->getName();
+        $run          = $runs->save_run($data, $source);
+        $this->runs[$test->getName()] = $this->options['xhprofWeb'] . '?run=' . $run .  '&source=' . $source;
     }
 
     /**


### PR DESCRIPTION
When using xhprof, we usually need to compare the run results with the same source.
But we can't compare the different task result, so for each
test, we should give it different source name (namespace + test name)