### PR TITLE
fix namespace bug

### DIFF
--- a/src/XHProfTestListener.php
+++ b/src/XHProfTestListener.php
@@ -104,64 +104,64 @@ class XHProfTestListener implements \PHPUnit_Framework_TestListener
     /**
      * An error occurred.
      *
-     * @param PHPUnit_Framework_Test $test
+     * @param \PHPUnit_Framework_Test $test
      * @param Exception              $e
      * @param float                  $time
      */
-    public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addError(\PHPUnit_Framework_Test $test, Exception $e, $time)
     {
     }
 
     /**
      * A failure occurred.
      *
-     * @param PHPUnit_Framework_Test                 $test
-     * @param PHPUnit_Framework_AssertionFailedError $e
+     * @param \PHPUnit_Framework_Test                 $test
+     * @param \PHPUnit_Framework_AssertionFailedError $e
      * @param float                                  $time
      */
-    public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
+    public function addFailure(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_AssertionFailedError $e, $time)
     {
     }
 
     /**
      * Incomplete test.
      *
-     * @param PHPUnit_Framework_Test $test
+     * @param \PHPUnit_Framework_Test $test
      * @param Exception              $e
      * @param float                  $time
      */
-    public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addIncompleteTest(\PHPUnit_Framework_Test $test, Exception $e, $time)
     {
     }
 
     /**
      * Skipped test.
      *
-     * @param PHPUnit_Framework_Test $test
+     * @param \PHPUnit_Framework_Test $test
      * @param Exception              $e
      * @param float                  $time
      */
-    public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addSkippedTest(\PHPUnit_Framework_Test $test, Exception $e, $time)
     {
     }
 
     /**
      * Risky test.
      *
-     * @param PHPUnit_Framework_Test $test
+     * @param \PHPUnit_Framework_Test $test
      * @param Exception              $e
      * @param float                  $time
      */
-    public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addRiskyTest(\PHPUnit_Framework_Test $test, Exception $e, $time)
     {
     }
 
     /**
      * A test started.
      *
-     * @param PHPUnit_Framework_Test $test
+     * @param \PHPUnit_Framework_Test $test
      */
-    public function startTest(PHPUnit_Framework_Test $test)
+    public function startTest(\PHPUnit_Framework_Test $test)
     {
         if (!isset($this->options['xhprofFlags'])) {
             $flags = XHPROF_FLAGS_CPU + XHPROF_FLAGS_MEMORY;
@@ -181,13 +181,13 @@ class XHProfTestListener implements \PHPUnit_Framework_TestListener
     /**
      * A test ended.
      *
-     * @param PHPUnit_Framework_Test $test
+     * @param \PHPUnit_Framework_Test $test
      * @param float                  $time
      */
-    public function endTest(PHPUnit_Framework_Test $test, $time)
+    public function endTest(\PHPUnit_Framework_Test $test, $time)
     {
         $data         = xhprof_disable();
-        $runs         = new XHProfRuns_Default;
+        $runs         = new \XHProfRuns_Default;
         $run          = $runs->save_run($data, $this->options['appNamespace']);
         $this->runs[$test->getName()] = $this->options['xhprofWeb'] . '?run=' . $run .
                                         '&source=' . $this->options['appNamespace'];
@@ -196,9 +196,9 @@ class XHProfTestListener implements \PHPUnit_Framework_TestListener
     /**
      * A test suite started.
      *
-     * @param PHPUnit_Framework_TestSuite $suite
+     * @param \PHPUnit_Framework_TestSuite $suite
      */
-    public function startTestSuite(PHPUnit_Framework_TestSuite $suite)
+    public function startTestSuite(\PHPUnit_Framework_TestSuite $suite)
     {
         $this->suites++;
     }
@@ -206,9 +206,9 @@ class XHProfTestListener implements \PHPUnit_Framework_TestListener
     /**
      * A test suite ended.
      *
-     * @param PHPUnit_Framework_TestSuite $suite
+     * @param \PHPUnit_Framework_TestSuite $suite
      */
-    public function endTestSuite(PHPUnit_Framework_TestSuite $suite)
+    public function endTestSuite(\PHPUnit_Framework_TestSuite $suite)
     {
         $this->suites--;
 


### PR DESCRIPTION
motivation:

PHP Catchable fatal error:  Argument 1 passed to PHPUnit\XHProfTestListener\XHProfTestListener::startTestSuite() must be an instance of PHPUnit\XHProfTestListener\PHPUnit_Framework_TestSuite, instance of PHPUnit_Framework_TestSuite given, called in /work/www/tsw/vendor/phpunit/phpunit/src/Framework/TestResult.php on line 303 and defined in /work/www/tsw/vendor/phpunit/test-listener-xhprof/src/XHProfTestListener.php on line 201

I suppose as soon as you've added
```
namespace PHPUnit\XHProfTestListener;
```
it needs \PHPUnit_Framework_* in code