### PR TITLE
Include the test class name in the resulting output.

### DIFF
--- a/src/XHProfTestListener.php
+++ b/src/XHProfTestListener.php
@@ -189,8 +189,9 @@ class XHProfTestListener implements \PHPUnit_Framework_TestListener
         $data         = xhprof_disable();
         $runs         = new \XHProfRuns_Default;
         $run          = $runs->save_run($data, $this->options['appNamespace']);
-        $this->runs[$test->getName()] = $this->options['xhprofWeb'] . '?run=' . $run .
-                                        '&source=' . $this->options['appNamespace'];
+        $test_name    = get_class($test) . '::' . $test->getName();
+        $this->runs[$test_name] = $this->options['xhprofWeb'] . '?run=' . $run .
+                                  '&source=' . $this->options['appNamespace'];
     }
 
     /**


### PR DESCRIPTION
This just prepends the test class name to the test method when outputting it to the console.

```
 * Method_Test::test_my_method
   http://xhprof.local/xhprof_html/index.php?run=54d910679c5b6&source=Testing
```

instead of

```
 * test_my_method
   http://xhprof.local/xhprof_html/index.php?run=54d910679c5b6&source=Testing
```